### PR TITLE
Replace ping multicast with scanning for APs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ cd examples/led
 platformio run
 ```
 
-### 4. Send out a ping
+### 4. Scan for bricks
 
 ```mqtt
-bricks/out/ff:ff:ff:ff:ff:ff/ping
+bricks/gateway/scan
 ```
 
-This will configure all bricks to use the gateway,
+This will configure all active bricks to use the gateway,
 each responding with a "pong" containing their MAC address and name:
 
 ```mqtt
@@ -77,7 +77,6 @@ brick:
 - [ ] Solve dropped messages problem
 - [ ] Refine pairing process
   - Need paired/unpaired status?
-  - Instead of ping-pong flow, bricks can scan for gateway? (if not configured)
   - If ACK is built in to all bricks, no need for `pong`?
 
 ### Nice to haves
@@ -91,15 +90,21 @@ brick:
 - [ ] Make aliexpress ble button send notifications
 - [ ] Idea: Move sender macAddr into message to reduce params to 1?
 - [ ] Idea: Reply with de-duped list of "capabilities" instead of name?
-- [ ] NodeRED - Allow payload, topic, mac to take msg input
+- [ ] NodeRED - Allow topic, mac to take msg input
 - [ ] NodeRED - Couple of exported flows
+- [ ] Use same system for defining mqtt responses (instead of hardcoded "scan")
+  ```
+  // Connect mqtt event stream
+  gEvents.init();
+  gEvents.events[0] = new ScanEvent();
+  gEvents.events[1] = new BroadcastEvent();
+  ```
 
 
 ### Unproven theories on dropped messages
 - ESP32s more stable than ESP8266s?
 - Is it better to use _all_ ESP32s / _all_ ESP8266s? ([interdevice comms flakey?](https://github.com/leonyuhanov/ESP-NOW-TX-RX#things-i-found-deep-in-the-rabbit-hole))
 - Related to modem sleep and the `WIFI_AP_STA` setting on the _gateway_? Lost ability to track send results with [WifiEspNow](https://github.com/yoursunny/WifiEspNow/blob/master/src/WifiEspNow.cpp#L141)
-- ESP8266 don't respond well to `FF:FF:FF:FF:FF:FF` broadcasts?
 - Are we doing ["lengthy operations"](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/network/esp_now.html#receiving-esp-now-data)?
 - Does ["data rate"](https://github.com/espressif/esp-idf/issues/3238) have any impact?
 - Does the "role" setting of ESP8266 have any impact?

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,11 +25,6 @@
 - Battery servo
 - ...more!
 
-## Supported Platforms
-
-- **ESP32**: Supports sending messages to multiple devices via `FF::FF::FF::FF::FF::FF`. Recommended for gateway.
-- **ESP8266**: Only supports sending messages to specific MAC addresses. Can be used for bricks.
-
 ## Hardware
 
 - [ ] Cases (Mesh-like form factor?)

--- a/examples/gateway/src/main.cpp
+++ b/examples/gateway/src/main.cpp
@@ -28,9 +28,7 @@ void setup() {
 
   // Enable receiving messages
   gInbox.init();
-
-  // Publish all received messages to mqtt
-  gInbox.actions[0] = new PublishAction();
+  gInbox.actions[0] = new PublishAction(); // Publish all received messages to mqtt
 }
 
 void loop() {

--- a/src/Bricks.Constants.h
+++ b/src/Bricks.Constants.h
@@ -1,10 +1,12 @@
 #ifndef BRICKS_CONSTANTS_H
 #define BRICKS_CONSTANTS_H
 
+#define BRICKS_NAME_PREFIX "Brick"
+#define BRICKS_PING_ACTION "ping"
 #define MAC_FORMAT "%02hhx:%02hhx:%02hhx:%02hhx:%02hhx:%02hhx"
 #define MAC_ADDR_SIZE 6
 #define MAC_STR_SIZE 18
-#define MAC_ALL {0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+#define MAC_UNSET {0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 #define MICROSECONDS 1000000
 #define KEY_SIZE 20
 

--- a/src/Bricks.Events.h
+++ b/src/Bricks.Events.h
@@ -27,6 +27,7 @@
 
 #define BRICKS_MESSAGES_IN BRICKS_MQTT_TOPIC_PREFIX "/in"
 #define BRICKS_MESSAGES_OUT BRICKS_MQTT_TOPIC_PREFIX "/out"
+#define BRICKS_MESSAGES_SCAN BRICKS_MQTT_TOPIC_PREFIX "/gateway/scan"
 
 namespace Bricks {
   class Events {
@@ -38,6 +39,7 @@ namespace Bricks {
       void loop();
       void publish(const uint8_t *macAddr, Message message);
       void publish(const uint8_t *macAddr, const char *key, const char *value = "");
+      void publish(const char *topic, const char *value = "");
       static void onEvent(char *topic, byte *bytes, unsigned int length);
       static void parseTopic(const char *topic, uint8_t *macAddr, char *key);
     private:
@@ -45,6 +47,8 @@ namespace Bricks {
       PubSubClient mqtt;
       void connectWiFi();
       void connectMQTT();
+      void subscribe(const char *topic);
+      static void scanForBricks();
   };
 
   extern Events gEvents;

--- a/src/Bricks.Outbox.h
+++ b/src/Bricks.Outbox.h
@@ -17,7 +17,7 @@ namespace Bricks {
       void setGatewayMac(const uint8_t *macAddr);
     private:
       void pair(const uint8_t *macAddr);
-      uint8_t gatewayMac[MAC_ADDR_SIZE] = MAC_ALL;
+      uint8_t gatewayMac[MAC_ADDR_SIZE] = MAC_UNSET;
   };
 
   extern Outbox gOutbox;

--- a/src/Bricks.PongAction.cpp
+++ b/src/Bricks.PongAction.cpp
@@ -1,8 +1,11 @@
 #include <Bricks.PongAction.h>
 
 namespace Bricks {
-  PongAction::PongAction(const char *name) : Action("ping") {
+  PongAction::PongAction(const char *name) : Action(BRICKS_PING_ACTION) {
     this->name = name;
+    char apName[50];
+    sprintf(apName, BRICKS_NAME_PREFIX " [%s]", name);
+    WiFi.softAP(apName, "1234567890", 0);
   }
 
   void PongAction::callback(const uint8_t *macAddr, const Message message) {

--- a/src/Bricks.PongAction.h
+++ b/src/Bricks.PongAction.h
@@ -3,12 +3,13 @@
 
 #include <ArduinoLog.h>
 #include <Bricks.Action.h>
+#include <Bricks.Constants.h>
 #include <Bricks.Outbox.h>
 
 namespace Bricks {
   class PongAction : public Action {
     public:
-      PongAction(const char *name = "brick");
+      PongAction(const char *name = "New Brick");
       void callback(const uint8_t *macAddr, const Message message);
     private:
       const char *name;


### PR DESCRIPTION
Replace flaky `FF::FF` multicasts with Bricks advertising APs + scanning.
Behavior is sort munged into Events in a non-flexible way for now. 
Maybe worth adopting a similar `actions` pattern for events if we want more Gateway specific commands?