### PR TITLE
Remove check for wake up reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,15 @@ Depending on your needs, it could be used to:
 
 ### Software
 
-- [ ] More matrix animations
-- [ ] Play specific frame of matrix animations
-- [ ] Fix [weird TravisCI error](https://travis-ci.org/github/balvig/bricks/jobs/738226714)
 - [ ] Write up making a custom brick
 - [ ] Write up building a Brick
 - [ ] Build something with PIR
 
 #### Nice to haves
+- [ ] Fix [weird TravisCI error](https://travis-ci.org/github/balvig/bricks/jobs/738226714)
+- [ ] More matrix animations
+- [ ] Play specific frame of matrix animations
 - [ ] Extract Lumi
-- [ ] ESP32 suffers from random brownouts on boot. Should sleep care about reset reason?
 - [ ] Try using `qos=1` for sending messages
 
 ### Hardware

--- a/src/Bricks.Outbox.cpp
+++ b/src/Bricks.Outbox.cpp
@@ -18,7 +18,7 @@ namespace Bricks {
 
     bool ok = WifiEspNow.send(macAddr, reinterpret_cast<const uint8_t*>(&message), sizeof(message));
     if(ok) {
-      Log.trace("ESPN: Sent message" CR);
+      Log.trace("ESPN: Message sent" CR);
     }
     else {
       Log.error("ESPN: Error sending message" CR);

--- a/src/Bricks.SleepSkill.cpp
+++ b/src/Bricks.SleepSkill.cpp
@@ -8,11 +8,7 @@ namespace Bricks {
   SleepSkill::SleepSkill(const char *name) : Skill("sleep") {
     this->name = name;
     sendAwakeMessage();
-
-    if(Utils::wokeUpFromDeepSleep()) {
-      Log.trace("SLEE: Woke up from deep sleep");
-      readSleepTime();
-    }
+    readSleepTime();
   }
 
   void SleepSkill::callback(BRICKS_CALLBACK_SIGNATURE) {
@@ -57,6 +53,7 @@ namespace Bricks {
 #elif ESP32
     sleepTime = Bricks::rtcSleepTime;
 #endif
+    Log.trace("SLEE: Sleep time read: %d" CR, sleepTime);
   }
 
   void SleepSkill::writeSleepTime() {

--- a/src/Bricks.Utils.cpp
+++ b/src/Bricks.Utils.cpp
@@ -22,15 +22,6 @@ namespace Bricks {
 #endif
   }
 
-  bool Utils::wokeUpFromDeepSleep() {
-    int info = resetInfo();
-#ifdef ESP8266
-    return info == REASON_DEEP_SLEEP_AWAKE;
-#elif ESP32
-    return info != ESP_SLEEP_WAKEUP_UNDEFINED;
-#endif
-  }
-
   void Utils::getWakeupReason(char *reason) {
     switch(resetInfo()) {
 #ifdef ESP8266

--- a/src/Bricks.Utils.h
+++ b/src/Bricks.Utils.h
@@ -25,7 +25,6 @@ namespace Bricks {
       static void macToStr(const uint8_t *macAddr, char *macStr);
       static void deepSleep(uint32_t sleepTime);
       static void getWakeupReason(char *reason);
-      static bool wokeUpFromDeepSleep();
     private:
       static int resetInfo();
   };


### PR DESCRIPTION
The idea was originally to allow resetting/unplugging/flashing to pull a Brick out of infinite sleep, but in practice it isn't very useful, and creates edge cases around whether to go back to sleep if the Brick loses power momentarily.