### PR TITLE
prevent crazy sleep values

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@ Depending on your needs, it could be used to:
 
 - [ ] Write up building a Brick
 - [ ] Build something with PIR
-- [ ] Fix random crazy sleep values
 
 #### Nice to haves
 - [ ] Extract Lumi

--- a/include/Bricks.SleepSkill.h
+++ b/include/Bricks.SleepSkill.h
@@ -18,6 +18,7 @@ namespace Bricks {
   class SleepSkill : public Skill {
     const uint32_t TIMEOUT = 2000;
     const uint32_t RTC_SLEEP_TIME_REGISTER = 65;
+    const uint32_t MAX_SLEEP_TIME = 10800; // seconds = 3 hours
 
     public:
       SleepSkill(const char *name = "New Brick");
@@ -27,6 +28,7 @@ namespace Bricks {
       void sendAwakeMessage();
       void deepSleep();
       bool awakeTimeout();
+      bool validSleepTime();
       void readSleepTime();
       void writeSleepTime();
       const char *name;

--- a/src/Bricks.SleepSkill.cpp
+++ b/src/Bricks.SleepSkill.cpp
@@ -15,11 +15,11 @@ namespace Bricks {
     this->sleepTime = atoi(message.value);
     writeSleepTime();
 
-    if(sleepTime > 0) {
+    if(validSleepTime()) {
       sprintf(response, "Starting %u second sleep cycles", sleepTime);
     }
     else {
-      strcpy(response, "Stopping sleep cycles");
+      sprintf(response, "Stopping sleep (Rec: %u, Max: %u)", sleepTime, MAX_SLEEP_TIME);
     }
   }
 
@@ -32,7 +32,7 @@ namespace Bricks {
   void SleepSkill::sendAwakeMessage() {
     char reason[50];
     char message[100];
-    Bricks::Utils::getWakeupReason(reason);
+    Utils::getWakeupReason(reason);
 
     sprintf(message, "%s - %s", name, reason);
     gOutbox.send("awake", message);
@@ -44,7 +44,11 @@ namespace Bricks {
   }
 
   bool SleepSkill::awakeTimeout() {
-    return sleepTime > 0 && millis() >= TIMEOUT;
+    return validSleepTime() && millis() >= TIMEOUT;
+  }
+
+  bool SleepSkill::validSleepTime() {
+    return sleepTime > 0 && sleepTime <= MAX_SLEEP_TIME;
   }
 
   void SleepSkill::readSleepTime() {


### PR DESCRIPTION
Every now and then there will be some junk in the RTC memory, erroneously prompting the Brick to sleep for an unreasonable long time.