### PR TITLE
allow Brick to return current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Depending on your needs, it could be used to:
 - [ ] Build something with PIR
 - [ ] Lumi battery checks
 - [ ] Permanent sleep
-- [ ] Get current commit version
 
 #### Nice to haves
 - [ ] Extract Lumi

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,5 +18,6 @@
 | ota     | ack:ota     | `pio run -t upload --upload-port 192.168.4.1` when connected to AP          |                            |
 | battery | ack:battery | Ask for battery value                                                       |                            |
 | skills  | ack:skills  | Get a list of actions the Brick responds to                                 |                            |
+| version | ack:version | Get commit hash                                                             |                            |
 |         | awake       | Sent when woken up                                                          | <NAME> - <REASON>          |
 |         | sleeping    | Sent when resuming sleep after 2 seconds of being awake during sleep cycles |                            |

--- a/include/Bricks.Brick.h
+++ b/include/Bricks.Brick.h
@@ -20,6 +20,7 @@
 #include <Bricks.ListSkill.h>
 #include <Bricks.OtaSkill.h>
 #include <Bricks.SleepSkill.h>
+#include <Bricks.VersionSkill.h>
 
 #define MAX_SKILLS 10
 

--- a/include/Bricks.VersionSkill.h
+++ b/include/Bricks.VersionSkill.h
@@ -1,0 +1,13 @@
+#ifndef BRICKS_VERSION_SKILL_H
+#define BRICKS_VERSION_SKILL_H
+
+#include <Bricks.Skill.h>
+
+namespace Bricks {
+  class VersionSkill : public Skill {
+    public:
+      VersionSkill();
+      void callback(BRICKS_CALLBACK_SIGNATURE) override;
+  };
+}
+#endif

--- a/shared.ini
+++ b/shared.ini
@@ -5,6 +5,7 @@ monitor_speed = 115200
 targets = upload, monitor
 lib_ldf_mode = chain+
 ; build_flags = -DDISABLE_LOGGING
+build_flags = !echo "'-DBRICKS_VERSION=\"$(git rev-parse HEAD)\"'"
 
 ; COMMON
 [common]

--- a/src/Bricks.Brick.cpp
+++ b/src/Bricks.Brick.cpp
@@ -3,6 +3,7 @@
 namespace Bricks {
   void Brick::init(const char *name) {
     initBase();
+    skills[5] = new VersionSkill();
     skills[6] = new OtaSkill();
     skills[7] = new ListSkill();
     skills[8] = new BatterySkill();

--- a/src/Bricks.VersionSkill.cpp
+++ b/src/Bricks.VersionSkill.cpp
@@ -1,0 +1,9 @@
+#include "Bricks.VersionSkill.h"
+
+namespace Bricks {
+  VersionSkill::VersionSkill() : Skill("version") {}
+
+  void VersionSkill::callback(BRICKS_CALLBACK_SIGNATURE) {
+    strcpy(response, BRICKS_VERSION);
+  }
+}


### PR DESCRIPTION
`version` skill returns current commit hash.